### PR TITLE
Bugfix: missing offset by origin parameter grid_position

### DIFF
--- a/isaac_ros_cumotion/isaac_ros_cumotion/cumotion_planner.py
+++ b/isaac_ros_cumotion/isaac_ros_cumotion/cumotion_planner.py
@@ -251,9 +251,9 @@ class CumotionActionServer(Node):
         self.get_logger().info('Calling ESDF service')
         # This is half of x,y and z dims
         aabb_min = Point()
-        aabb_min.x = -1 * self.__voxel_dims[0] / 2
-        aabb_min.y = -1 * self.__voxel_dims[1] / 2
-        aabb_min.z = -1 * self.__voxel_dims[2] / 2
+        aabb_min.x = (-0.5 * self.__voxel_dims[0]) + self.__grid_position[0]
+        aabb_min.y = (-0.5 * self.__voxel_dims[1]) + self.__grid_position[1]
+        aabb_min.z = (-0.5 * self.__voxel_dims[2]) + self.__grid_position[2]
         # This is a voxel size.
         voxel_dims = Vector3()
         voxel_dims.x = self.__voxel_dims[0]


### PR DESCRIPTION
In the function `update_voxel_grid` the parameter grid_position is not used. This is causing issues for any setting with `grid_position != [0,0,0]`, where the ESDF and therefore the collision objects are offset to where they should be. This can be observed using rviz.

I suspect that the package `isaac_ros_esdf_visualizer` uses the parameter grid_position as intended. 